### PR TITLE
Fixes running phantomjs on Windows. Windows expects ";" as delimiter for...

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "selenium-launcher": "git://github.com/drd/nodejs-selenium-launcher.git",
+    "selenium-launcher": "git://github.com/peerigon/nodejs-selenium-launcher.git",
     "wd": "~0.2.0",
     "mocha": "~1.12.0",
     "phantomjs": "~1.9.1",

--- a/tasks/mocha-selenium.js
+++ b/tasks/mocha-selenium.js
@@ -10,6 +10,9 @@ module.exports = function(grunt) {
   var wd = require('wd');
   var phantomjs = require('phantomjs');
   var path = require('path');
+  var os = require("os");
+  var isWin = os.platform().search(/win/i) > -1;
+  var PATHDelimiter = isWin ? ";" : ":";
 
   grunt.registerMultiTask('mochaSelenium', 'Run functional tests with mocha', function() {
     var done = this.async();
@@ -63,7 +66,7 @@ module.exports = function(grunt) {
 
     if (options.browserName === 'phantomjs' && !options.useSystemPhantom) {
       // add npm-supplied phantomjs bin dir to PATH, so selenium can launch it
-      process.env.PATH = path.dirname(phantomjs.path) + ':' + process.env.PATH;
+      process.env.PATH = path.dirname(phantomjs.path) + PATHDelimiter + process.env.PATH;
     }
 
     seleniumLauncher({ chrome: options.browserName === 'chrome' }, function(err, selenium) {

--- a/tasks/mocha-selenium.js
+++ b/tasks/mocha-selenium.js
@@ -11,7 +11,7 @@ module.exports = function(grunt) {
   var phantomjs = require('phantomjs');
   var path = require('path');
   var os = require("os");
-  var isWin = os.platform().search(/win/i) > -1;
+  var isWin = os.platform().search(/win/i) === 0;
   var PATHDelimiter = isWin ? ";" : ":";
 
   grunt.registerMultiTask('mochaSelenium', 'Run functional tests with mocha', function() {


### PR DESCRIPTION
... PATH variable.

We were exactly looking for a grunt-task like grunt-mocha-selenium. Thanks for your great work.
But we had the problem that phantomjs wasn't executed on Windows. This will fix it.
