### PR TITLE
Add support for sauce connect as alternative to local selenium server

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "selenium-launcher": "git://github.com/drd/nodejs-selenium-launcher.git",
+    "selenium-launcher": "git://github.com/wookiehangover/nodejs-selenium-launcher.git",
     "wd": "~0.2.0",
     "mocha": "~1.12.0",
     "phantomjs": "~1.9.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "mocha": "~1.12.0",
     "phantomjs": "~1.9.1",
     "async": "~0.2.9",
-    "freeport": "~1.0.2"
+    "freeport": "~1.0.2",
+    "sauce-tunnel": "~1.1.0"
   }
 }


### PR DESCRIPTION
Let me know your thoughts on this - I wanted to have the ability to switch back and forth between running WD/mocha tests locally and in sauce labs (e.g. for development vs. continuous integration), so I modified the mocha-selenium task to support either or.

I've held off on making the relevant changes to the README file or writing any tests because I wanted to get your thoughts on this approach first - does this seem reasonable to you? I considered putting this functionality in selenium-launcher itself, but this made more sense to me.
