### PR TITLE
Add chrome options

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,11 @@ grunt.initConfig({
       src: ['test/*.js'],
       options: {
         // Chrome browser must be installed from Chromedriver support
-        browserName: 'chrome'
+        browserName: 'chrome',
+        chromeOptions: {
+          // Any valid chrome capability:
+          // https://sites.google.com/a/chromium.org/chromedriver/capabilities
+        }
       }
     },
     phantomjs: {

--- a/tasks/mocha-selenium.js
+++ b/tasks/mocha-selenium.js
@@ -80,7 +80,8 @@ module.exports = function(grunt) {
       var browser = wd[remote](selenium.host, selenium.port);
 
       var opts = {
-        browserName: options.browserName
+        browserName: options.browserName,
+        chromeOptions: options.chromeOptions
       };
 
       browser.on('status', function(info){


### PR DESCRIPTION
This allows anyone to add capabilities to the chrome browser such as extensions and command line switches.

Valid chrome options: https://sites.google.com/a/chromium.org/chromedriver/capabilities

Usage example:

```
options: {
    browserName: 'chrome',
        chromeOptions: {
            args: ['--allow-running-insecure-content']
        }
}
```
