### PR TITLE
Add support for specifying firefox profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,12 @@ grunt.initConfig({
       usePromises: false
     },
     firefox: {
-      src: ['test/*.js']
+      src: ['test/*.js'],
       // firefox is the default browser, so no browserName option required
+      options: {
+        firefox_profile: // Optionally pass in a firefox profile
+      }
+    }
     },
     chrome: {
       src: ['test/*.js'],

--- a/tasks/mocha-selenium.js
+++ b/tasks/mocha-selenium.js
@@ -80,7 +80,8 @@ module.exports = function(grunt) {
       var browser = wd[remote](selenium.host, selenium.port);
 
       var opts = {
-        browserName: options.browserName
+        browserName: options.browserName,
+        firefox_profile: options.firefox_profile
       };
 
       browser.on('status', function(info){


### PR DESCRIPTION
Allows user to specify a firefox profile to run the tests with.  This allows you to add extensions and specify any settings found in about:config (http://kb.mozillazine.org/Firefox_:_FAQs_:_About:config_Entries).

Can create a firefox profile using https://npmjs.org/package/firefox-profile
