### PR TITLE
Allow external selenium server to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ If enabled, this will use the [promise-enabled wd browser
 API](https://github.com/admc/wd#promises-api) instead of the normal
 synchronous API.
 
+### options.host and options.port
+
+If these are specified then a server will not be started but these settings will be used to connect to an existing server.
+
+"options.username" and "options.accesskey" can be specified if you want to use Sauce Labs' on demand service.
+
 ## The "mochaAppium" task
 
 The "mochaAppium" task will use the [Appium](http://appium.io/) test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-mocha-selenium",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Run functional Mocha tests with webdriver against a local selenium instance.",
   "homepage": "https://github.com/wookiehangover/grunt-mocha-selenium",
   "bugs": "https://github.com/wookiehangover/grunt-mocha-selenium/issues",


### PR DESCRIPTION
If options.host and options.port are given use them rather than starting a new server.

also passes more options to selenium so appium capabilites can be specified when running on sauce labs
