### PR TITLE
Terminate the script with non-zero exit if error occurs.

### DIFF
--- a/tasks/mocha-selenium.js
+++ b/tasks/mocha-selenium.js
@@ -130,6 +130,10 @@ module.exports = function(grunt) {
                 selenium.kill();
               }
               mochaDone(err);
+
+              if (err) {
+                 grunt.fail.warn('One or more tests failed.');
+              }
             });
           });
         });


### PR DESCRIPTION
I know this script probably isn't written well enough, but is there anyway to implement something similar to this non-zero exit if a test does fail? https://github.com/wookiehangover/grunt-mocha-selenium/issues/24
