### PR TITLE
PhantomJS driver does not launch on Windows

### DIFF
--- a/tasks/mocha-selenium.js
+++ b/tasks/mocha-selenium.js
@@ -70,7 +70,12 @@ module.exports = function(grunt) {
 
       if (options.browserName === 'phantomjs' && !options.useSystemPhantom) {
         // add npm-supplied phantomjs bin dir to PATH, so selenium can launch it
-        process.env.PATH = path.dirname(phantomjs.path) + ':' + process.env.PATH;
+		var isWin = /^win/.test(process.platform);
+		if (isWin) {
+			process.env.PATH = path.dirname(phantomjs.path) + ';' + process.env.PATH;
+		} else {
+			process.env.PATH = path.dirname(phantomjs.path) + ':' + process.env.PATH;
+		}
       }
 
       seleniumLauncher({ chrome: options.browserName === 'chrome' }, function(err, selenium) {

--- a/tasks/mocha-selenium.js
+++ b/tasks/mocha-selenium.js
@@ -95,8 +95,12 @@ module.exports = function(grunt) {
     // When we're done with mocha, dispose the domain
     var mochaDone = function(errCount) {
       var withoutErrors = (errCount === 0);
-      // Indicate whether we failed to the grunt task runner
-      next(withoutErrors);
+	  if (!withoutErrors) {
+		grunt.fail.fatal('Number of failed tests: ' + errCount);
+	  } else {
+		  // Indicate whether we failed to the grunt task runner
+		  next(withoutErrors);
+	  }
     };
 
     var remote = options.usePromises ? 'promiseRemote' : 'remote';


### PR DESCRIPTION
When not using a system path for PhantomJS, the process env. path is
appended to include the PhantomJS directory from the node dependencies.
However, this path concatenation uses colon, which works on *nix and mac
machines, but not on Windows. Windows requires path concatenation with
semi-colon.
